### PR TITLE
Testcase fix and simple client example

### DIFF
--- a/cap/atom_test.go
+++ b/cap/atom_test.go
@@ -299,8 +299,8 @@ func TestGetNwsAtomFeed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if feed.ID != "http://alerts.weather.gov/cap/us.atom" {
-		t.Fatal("Feed did not download / parse correctly")
+	if feed.ID != "https://alerts.weather.gov/cap/us.php?x=0" {
+		t.Fatalf("feed.ID is: %s but we expected: %s", feed.ID, "http://alerts.weather.gov/cap/us.atom")
 	}
 }
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	cap "github.com/mark-adams/cap-go/cap"
+	"github.com/urfave/cli"
+)
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "pull"
+	app.Usage = "pull CAP alerts"
+	app.Action = func(c *cli.Context) error {
+		fmt.Println("pulling CAP alerts from NWS")
+		feed, err := cap.GetNWSAtomFeed()
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%v", feed)
+		return nil
+	}
+
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
The first commit allows the testing to pass with the change to the feed.ID.

The second commit adds a simple client example to dump output from the feed.